### PR TITLE
Add lots more papers

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -5,20 +5,21 @@ title: Papers
 # Chronological Order
 
 - [A Survey of Russian Approaches to Perebor (Brute-Force Searches)
-  Algorithms,](https://ieeexplore.ieee.org/document/4640789/) Boris
-  A. Trakhtenbrot, 1984.
+  Algorithms.](https://ieeexplore.ieee.org/document/4640789/)
+  Boris A. Trakhtenbrot. 1984.
 - [Circuit Minimization
-  Problem,](https://eccc.weizmann.ac.il//eccc-reports/1999/TR99-045/index.html)
-  Valentine Kabanets and Jin-yi Cai, 1999.
-- Power from Random Strings, Eric Allender, Harry Buhrman, Michal
-  Koucký, Dieter van Melkebeek, Detlef Ronneburger, 2006.
-- On the (Non) NP-Hardness of Computing Circuit Complexity, Cody
-  D. Murray, Richard Ryan Williams, 2015.
-- Minimum Circuit Size, Graph Isomorphism, and Related Problems, Eric
-  Allender, Joshua A. Grochow, Dieter van Melkebeek, Cris Moore,
-  Andrew Morgan, 2017.
-- NP-hardness of Minimum Circuit Size Problem for OR-AND-MOD Circuits,
-  Shuichi Hirahara, Igor Carboni Oliveira, Rahul Santhanam, 2018.
+  Problem.](https://eccc.weizmann.ac.il//eccc-reports/1999/TR99-045/index.html)
+  Valentine Kabanets, Jin-yi Cai. 1999.
+- Power from Random Strings.
+  Eric Allender, Harry Buhrman, Michal Koucký, Dieter van Melkebeek,
+  Detlef Ronneburger. 2006.
+- On the (Non) NP-Hardness of Computing Circuit Complexity.
+  Cody D. Murray, Richard Ryan Williams. 2015.
+- Minimum Circuit Size, Graph Isomorphism, and Related Problems.
+  Eric Allender, Joshua A. Grochow, Dieter van Melkebeek, Cris Moore,
+  Andrew Morgan. 2017.
+- NP-hardness of Minimum Circuit Size Problem for OR-AND-MOD Circuits.
+  Shuichi Hirahara, Igor Carboni Oliveira, Rahul Santhanam. 2018.
 
 
 

--- a/papers.md
+++ b/papers.md
@@ -7,19 +7,114 @@ title: Papers
 - [A Survey of Russian Approaches to Perebor (Brute-Force Searches)
   Algorithms.](https://ieeexplore.ieee.org/document/4640789/)
   Boris A. Trakhtenbrot. 1984.
+- [The Minimum Equivalent DNF Problem and Shortest
+  Implicants.](http://dx.doi.org/10.1006/jcss.2001.1775)
+  Chris Umans. 1998.
+- [On the Complexity and Inapproximability of Shortest Implicant
+  Problem.](http://users.cms.caltech.edu/~umans/papers/U99a.ps) (.ps
+  file)
+  Chris Umans. 1999. Results also appear
+  [here](http://dx.doi.org/10.1006/jcss.2001.1775).
+- [Hardness of Approximating Sigma2 Minimization
+  Problems.](http://users.cms.caltech.edu/~umans/papers/U99b.ps) (.ps
+  file)
+  Chris Umans. 1999.
 - [Circuit Minimization
-  Problem.](https://eccc.weizmann.ac.il//eccc-reports/1999/TR99-045/index.html)
-  Valentine Kabanets, Jin-yi Cai. 1999.
-- Power from Random Strings.
+  Problem.](https://eccc.weizmann.ac.il/report/1999/045)
+  Valentine Kabanets, Jin-Yi Cai. 1999.
+- [When Worlds Collide: Derandomization, Lower Bounds, and Kolmogorov
+  Complexity.](https://link.springer.com/chapter/10.1007/3-540-45294-X_1)
+  ([alt. pdf](http://ftp.cs.rutgers.edu/pub/allender/fsttcs01.pdf))
+  Eric Allender. 2001.
+- [Power from Random
+  Strings.](https://eccc.weizmann.ac.il/report/2002/028)
   Eric Allender, Harry Buhrman, Michal Koucký, Dieter van Melkebeek,
-  Detlef Ronneburger. 2006.
-- On the (Non) NP-Hardness of Computing Circuit Complexity.
-  Cody D. Murray, Richard Ryan Williams. 2015.
-- Minimum Circuit Size, Graph Isomorphism, and Related Problems.
+  Detlef Ronneburger. 2002.
+- [Minimizing DNF Formulas and AC0 Circuits Given a
+  Truth Table.](https://eccc.weizmann.ac.il/report/2005/126/)
+  Eric Allender, Lisa Hellerstein, Paul McCabe, Michael Saks. 2005.
+- [Hardness of Approximate Two-level Logic Minimization and PAC Learning
+  with Membership Queries.](https://eccc.weizmann.ac.il/report/2005/127)
+  Vitaly Feldman. 2005.
+- Nondeterministic Circuit Minimization Problem and Derandomizing
+  Arthur-Merlin Games. (link?)
+  Variyam Vinodchandran. 2005.
+- [The Complexity of Boolean Formula
+  Minimization.](http://dx.doi.org/10.1016/j.jcss.2010.06.011)
+  David Buchfuhrer, Christopher Umans. 2008.
+- [The Pervasive Reach of Resource-Bounded Kolmogorov Complexity in
+  Computational Complexity
+  Theory.](https://eccc.weizmann.ac.il/report/2009/051/)
+  Eric Allender, Michal Koucky, Detlef Ronneburger, Sambuddha Roy. 2009.
+- [Improved Inapproximability Factors for Some Sigma2^p Minimization
+  Problems.](https://eccc.weizmann.ac.il/report/2009/107)
+  Kevin Dick, Chris Umans. 2009.
+- [Avoiding Simplicity is Complex](https://eccc.weizmann.ac.il/report/2010/055)
+  Eric Allender, Holger Spakowski. 2010.
+- [Reductions to the set of random strings: the resource-bounded
+  case.](https://eccc.weizmann.ac.il/report/2012/054/)
+  Eric Allender, Harry Burhman, Luke Friedman, Bruno Loff. 2012.
+- [Compression of Boolean
+  Functions.](https://eccc.weizmann.ac.il/report/2013/024/)
+  Valentine Kabanets, Antonina Kolokolova. 2013.
+- [Mining Circuit Lower Bound Proofs for
+  Meta-Algorithms.](https://eccc.weizmann.ac.il/report/2013/057/)
+  Ruiwen Chen, Valentine Kabanets, Antonina Kolokolova, Ronen Shaltiel,
+  David Zuckerman. 2013.
+- [Zero Knowledge and Circuit
+  Minimization.](https://eccc.weizmann.ac.il/report/2014/068/)
+  Eric Allender, Bireswar Das. 2014.
+- [The Minimum Oracle Circuit Size
+  Problem.](https://eccc.weizmann.ac.il/report/2014/176/)
+  Eric Allender, Dhiraj Holden, Valentine Kabanets. 2014.
+- [On the (Non) NP-Hardness of Computing Circuit
+  Complexity.](https://eccc.weizmann.ac.il/report/2014/164)
+  Cody D. Murray, Richard Ryan Williams. 2014.
+- [Limits of Minimum Circuit Size Problem as
+  Oracle.](https://eccc.weizmann.ac.il/report/2015/198/)
+  Shuichi Hirahara, Osamu Watanabe. 2015.
+- [On the NP-Completeness of the Minimum Circuit Size
+  Problem](http://drops.dagstuhl.de/opus/volltexte/2015/5661/)
+  John Hitchcock, A. Pavan. 2015.
+- [Algorithms from Natural Lower
+  Bounds.](https://eccc.weizmann.ac.il/report/2016/008/)
+  Marco Carmosino, Russell Impagliazzo, Valentine Kabanets, Antonina
+  Kolokolova. 2016.
+- [Discrete Logarithm and Minimum Circuit
+  Size.](https://eccc.weizmann.ac.il/report/2016/108/)
+  Michael Rudow. 2016.
+- [Complexity of
+  Complexity](https://link.springer.com/chapter/10.1007/978-3-319-50062-1_6)
+  ([alt. pdf](http://ftp.cs.rutgers.edu/pub/allender/downey.pdf))
+  Eric Allender. 2016.
+- [Conspiracies between Learning Algorithms, Circuit Lower Bounds and
+  Pseudorandomness.](https://eccc.weizmann.ac.il/report/2016/197/)
+  Igor Carboni Oliveira, Rahul Santhanam. 2016.
+- [The Power of Natural Properties as
+  Oracles.](https://eccc.weizmann.ac.il/report/2017/023/)
+  Russell Impagliazzo, Valentine Kabanets, Ilya Volkovich. 2017.
+- [New Insights on the (Non)-Hardness of Circuit Minimization and Related
+  Problems.](https://eccc.weizmann.ac.il/report/2017/073)
+  Eric Allender, Shuichi Hirahara. 2017.
+- [On the Average-Case Complexity of MCSP and Its
+  Variants](http://drops.dagstuhl.de/opus/volltexte/2017/7540/)
+  Shuichi Hirahara, Rahul Santhanam. 2017.
+- [Agnostic Learning from Tolerant Natural
+  Proofs.](http://drops.dagstuhl.de/opus/volltexte/2017/7584/)
+  Marco Carmosino, Russell Impagliazzo, Valentine Kabanets, Antonina
+  Kolokolova. 2017.
+- [Minimum Circuit Size, Graph Isomorphism, and Related
+  Problems.](https://eccc.weizmann.ac.il/report/2017/158)
   Eric Allender, Joshua A. Grochow, Dieter van Melkebeek, Cris Moore,
   Andrew Morgan. 2017.
-- NP-hardness of Minimum Circuit Size Problem for OR-AND-MOD Circuits.
+- [NP-hardness of Minimum Circuit Size Problem for OR-AND-MOD
+  Circuits.](https://eccc.weizmann.ac.il/report/2018/030)
   Shuichi Hirahara, Igor Carboni Oliveira, Rahul Santhanam. 2018.
-
+- [Non-black-box Worst-case to Average-case Reductions within
+  NP.](https://eccc.weizmann.ac.il/report/2018/138)
+  Shuichi Hirahara. 2018.
+- [Hardness Magnification for Natural
+  Problems.](https://eccc.weizmann.ac.il/report/2018/139/)
+  Igor Carboni Oliveira, Rahul Santhanam. 2018.
 
 


### PR DESCRIPTION
Add many papers related to MCSP, compression of functions, resource-bounded Kolmogorov complexity, learning small circuit hypotheses. The list was generated by looking through ECCC, some more active authors' web pages, and bibliographies of some papers, and picking out papers that either explicitly deal with MCSP or that I otherwise know to be related to MCSP. No effort was made to filter the papers besides for relevance.

Notably still missing are
(1) almost anything before 2000
(2) some papers with direct learning algorithms
(3) probably quite a few others that I missed by not being completely systematic